### PR TITLE
Fix issue auth

### DIFF
--- a/api/views/auth.py
+++ b/api/views/auth.py
@@ -322,7 +322,8 @@ class AuthStatusView(APIView):
                         "email": request.user.email,
                         "first_name": request.user.first_name,
                         "last_name": request.user.last_name,
-                        "last_logged_in": request.user.last_login,
+                        # Use ISO string for strict JSON safety
+                        "last_logged_in": request.user.last_login.isoformat() if request.user.last_login else None,
                     },
                     "profile": {
                         "id": str(profile.uuid),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auth status response now returns the user’s last_login as an ISO 8601 string or null, ensuring consistent, standardized date formatting across clients.
  * Improves compatibility with front-end displays and external integrations that expect string-based timestamps.
  * No changes to other fields or response structure; only the last_login representation has been updated.
  * Backward behavior note: consumers relying on non-string datetime objects should adjust to the string/null format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->