### PR TITLE
Potential fix for code scanning alert no. 74: Failure to use secure cookies

### DIFF
--- a/api/views/auth/auth_viewset.py
+++ b/api/views/auth/auth_viewset.py
@@ -122,7 +122,7 @@ def set_auth_cookies(response: Response, access: str, refresh: str) -> Response:
     # Cookie SameSite configuration: default to 'None' for cross-site frontend/backend
     same_site = (
         getattr(settings, "REST_AUTH", {}).get("JWT_AUTH_SAMESITE")
-        or "None"
+        or "Lax"
     )
     access_age = _get_max_age(getattr(settings, "SIMPLE_JWT", {}).get(
         "ACCESS_TOKEN_LIFETIME", timedelta(minutes=5)), 300)


### PR DESCRIPTION
Potential fix for [https://github.com/kuth-chi/eductionhub/security/code-scanning/74](https://github.com/kuth-chi/eductionhub/security/code-scanning/74)

To fix the problem, ensure the `SameSite` attribute on cookies containing authentication tokens is set to `"Lax"` (or `"Strict"` if practical for the app), rather than `"None"`. This addresses the risk of CSRF attacks on sensitive tokens. The best solution is to change the default value used for `same_site` for authentication cookies so that if the relevant Django setting is missing or misconfigured, `SameSite="Lax"` is used. This change should be applied where `same_site` is defined, so both access and refresh token cookies are updated. Note: The frontend status cookie ("auth_status") may remain with the current configuration if it is not security-sensitive, but for consistency you may wish to also strengthen its default.

Specifically:
- On line 125, change the default fallback for `same_site` from `"None"` to `"Lax"` (or `"Strict"` if feasible).
- No new imports or methods required as the logic is local.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default SameSite attribute for authentication cookies to Lax when not explicitly configured. This standardizes behavior across environments and reduces reliance on third‑party cookies. Existing cookies are unaffected; newly issued session cookies will use SameSite=Lax by default. Cross-site sign-in or embedded flows may require adjustments if they depended on SameSite=None. Other cookie attributes and validation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->